### PR TITLE
Seed both online accounts apis

### DIFF
--- a/touch-amd64
+++ b/touch-amd64
@@ -251,3 +251,5 @@ wget
 whoopsie
 wireless-tools
 ubuntu-location-provider-geoclue2
+accounts-qml-module
+online-accounts-api

--- a/touch-armhf
+++ b/touch-armhf
@@ -247,3 +247,5 @@ cgroup-lite
 cgroupfs-mount
 cups
 timekeeper
+accounts-qml-module
+online-accounts-api


### PR DESCRIPTION
vivid had 2 online accounts api's this adds both packages to xenial so we don't break apps. 

See https://github.com/ubports/ubuntu-touch/issues/412 for discussion on deprecating the old accounts-qml-module api