### PR TITLE
Fix wrong sdklibs package version on amd64/i386

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ubuntu-touch-meta (1.333xenial1ubports2) xenial; urgency=medium
+
+  * Bump to libjsoncpp1 on amd64 & i386
+  * Bump to libnet-cpp2 on amd64 & i386
+  * Bump to libprocess-cpp3 on amd64 & i386
+
+ -- Dan Chapman <dan@ubports.com>  Sun, 18 Feb 2018 09:37:12 +0000
+
 ubuntu-touch-meta (1.333xenial1ubports1) xenial; urgency=medium
 
   * Sync with xenial

--- a/sdk-libs-amd64
+++ b/sdk-libs-amd64
@@ -1,7 +1,7 @@
 libcontent-hub0
-libjsoncpp0
-libnet-cpp1
-libprocess-cpp2
+libjsoncpp1
+libnet-cpp2
+libprocess-cpp3
 libqt5keychain0
 libqt5multimedia5-plugins
 libqt5script5

--- a/sdk-libs-i386
+++ b/sdk-libs-i386
@@ -1,7 +1,7 @@
 libcontent-hub0
-libjsoncpp0
-libnet-cpp1
-libprocess-cpp2
+libjsoncpp1
+libnet-cpp2
+libprocess-cpp3
 libqt5keychain0
 libqt5multimedia5-plugins
 libqt5script5


### PR DESCRIPTION
Bumps libjsoncpp, libnet-cpp and libprocess-cpp to match what we already have for armhf