### PR TITLE
Remove U1DB

### DIFF
--- a/sdk-libs-amd64
+++ b/sdk-libs-amd64
@@ -29,7 +29,6 @@ qtdeclarative5-particles-plugin
 qtdeclarative5-poppler1.0
 qtdeclarative5-qtorganizer-plugin
 qtdeclarative5-qtquick2-plugin
-qtdeclarative5-u1db1.0
 qtdeclarative5-ubuntu-content1
 qtdeclarative5-ubuntu-download-manager0.1
 qtdeclarative5-ubuntu-mediascanner0.1

--- a/sdk-libs-arm64
+++ b/sdk-libs-arm64
@@ -29,7 +29,6 @@ qtdeclarative5-particles-plugin
 qtdeclarative5-poppler1.0
 qtdeclarative5-qtorganizer-plugin
 qtdeclarative5-qtquick2-plugin
-qtdeclarative5-u1db1.0
 qtdeclarative5-ubuntu-content1
 qtdeclarative5-ubuntu-download-manager0.1
 qtdeclarative5-ubuntu-mediascanner0.1

--- a/sdk-libs-armhf
+++ b/sdk-libs-armhf
@@ -29,7 +29,6 @@ qtdeclarative5-particles-plugin
 qtdeclarative5-poppler1.0
 qtdeclarative5-qtorganizer-plugin
 qtdeclarative5-qtquick2-plugin
-qtdeclarative5-u1db1.0
 qtdeclarative5-ubuntu-content1
 qtdeclarative5-ubuntu-download-manager0.1
 qtdeclarative5-ubuntu-mediascanner0.1

--- a/sdk-libs-i386
+++ b/sdk-libs-i386
@@ -29,7 +29,6 @@ qtdeclarative5-particles-plugin
 qtdeclarative5-poppler1.0
 qtdeclarative5-qtorganizer-plugin
 qtdeclarative5-qtquick2-plugin
-qtdeclarative5-u1db1.0
 qtdeclarative5-ubuntu-content1
 qtdeclarative5-ubuntu-download-manager0.1
 qtdeclarative5-ubuntu-mediascanner0.1


### PR DESCRIPTION
This removes U1DB from the sdk meta packages

See https://github.com/ubports/ubuntu-touch/issues/96