### PR TITLE
Remove all unsuported frameworks

### DIFF
--- a/frameworks/ubuntu-sdk-13.10.framework
+++ b/frameworks/ubuntu-sdk-13.10.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 13.10

--- a/frameworks/ubuntu-sdk-14.04-dev1.framework
+++ b/frameworks/ubuntu-sdk-14.04-dev1.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 14.04

--- a/frameworks/ubuntu-sdk-14.04-html-dev1.framework
+++ b/frameworks/ubuntu-sdk-14.04-html-dev1.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 14.04

--- a/frameworks/ubuntu-sdk-14.04-html.framework
+++ b/frameworks/ubuntu-sdk-14.04-html.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 14.04

--- a/frameworks/ubuntu-sdk-14.04-papi-dev1.framework
+++ b/frameworks/ubuntu-sdk-14.04-papi-dev1.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 14.04

--- a/frameworks/ubuntu-sdk-14.04-papi.framework
+++ b/frameworks/ubuntu-sdk-14.04-papi.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 14.04

--- a/frameworks/ubuntu-sdk-14.04-qml-dev1.framework
+++ b/frameworks/ubuntu-sdk-14.04-qml-dev1.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 14.04

--- a/frameworks/ubuntu-sdk-14.04-qml.framework
+++ b/frameworks/ubuntu-sdk-14.04-qml.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 14.04

--- a/frameworks/ubuntu-sdk-14.04.framework
+++ b/frameworks/ubuntu-sdk-14.04.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 14.04

--- a/frameworks/ubuntu-sdk-14.10-dev1.framework
+++ b/frameworks/ubuntu-sdk-14.10-dev1.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 14.10

--- a/frameworks/ubuntu-sdk-14.10-dev2.framework
+++ b/frameworks/ubuntu-sdk-14.10-dev2.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 14.10

--- a/frameworks/ubuntu-sdk-14.10-html-dev1.framework
+++ b/frameworks/ubuntu-sdk-14.10-html-dev1.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 14.10

--- a/frameworks/ubuntu-sdk-14.10-html-dev2.framework
+++ b/frameworks/ubuntu-sdk-14.10-html-dev2.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 14.10

--- a/frameworks/ubuntu-sdk-14.10-html.framework
+++ b/frameworks/ubuntu-sdk-14.10-html.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 14.10

--- a/frameworks/ubuntu-sdk-14.10-papi-dev1.framework
+++ b/frameworks/ubuntu-sdk-14.10-papi-dev1.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 14.10

--- a/frameworks/ubuntu-sdk-14.10-papi-dev2.framework
+++ b/frameworks/ubuntu-sdk-14.10-papi-dev2.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 14.10

--- a/frameworks/ubuntu-sdk-14.10-papi.framework
+++ b/frameworks/ubuntu-sdk-14.10-papi.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 14.10

--- a/frameworks/ubuntu-sdk-14.10-qml-dev1.framework
+++ b/frameworks/ubuntu-sdk-14.10-qml-dev1.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 14.10

--- a/frameworks/ubuntu-sdk-14.10-qml-dev2.framework
+++ b/frameworks/ubuntu-sdk-14.10-qml-dev2.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 14.10

--- a/frameworks/ubuntu-sdk-14.10-qml-dev3.framework
+++ b/frameworks/ubuntu-sdk-14.10-qml-dev3.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 14.10

--- a/frameworks/ubuntu-sdk-14.10-qml.framework
+++ b/frameworks/ubuntu-sdk-14.10-qml.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 14.10

--- a/frameworks/ubuntu-sdk-14.10.framework
+++ b/frameworks/ubuntu-sdk-14.10.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 14.10

--- a/frameworks/ubuntu-sdk-15.04-html.framework
+++ b/frameworks/ubuntu-sdk-15.04-html.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04-papi.framework
+++ b/frameworks/ubuntu-sdk-15.04-papi.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04-qml.framework
+++ b/frameworks/ubuntu-sdk-15.04-qml.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.1-html.framework
+++ b/frameworks/ubuntu-sdk-15.04.1-html.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.1-papi.framework
+++ b/frameworks/ubuntu-sdk-15.04.1-papi.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.1-qml.framework
+++ b/frameworks/ubuntu-sdk-15.04.1-qml.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.1.framework
+++ b/frameworks/ubuntu-sdk-15.04.1.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.2-html.framework
+++ b/frameworks/ubuntu-sdk-15.04.2-html.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.2-papi.framework
+++ b/frameworks/ubuntu-sdk-15.04.2-papi.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.2-qml.framework
+++ b/frameworks/ubuntu-sdk-15.04.2-qml.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.2.framework
+++ b/frameworks/ubuntu-sdk-15.04.2.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.3-html.framework
+++ b/frameworks/ubuntu-sdk-15.04.3-html.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.3-papi.framework
+++ b/frameworks/ubuntu-sdk-15.04.3-papi.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.3-qml.framework
+++ b/frameworks/ubuntu-sdk-15.04.3-qml.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.3.framework
+++ b/frameworks/ubuntu-sdk-15.04.3.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.4-html.framework
+++ b/frameworks/ubuntu-sdk-15.04.4-html.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.4-papi.framework
+++ b/frameworks/ubuntu-sdk-15.04.4-papi.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.4-qml.framework
+++ b/frameworks/ubuntu-sdk-15.04.4-qml.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.4.framework
+++ b/frameworks/ubuntu-sdk-15.04.4.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.5-html.framework
+++ b/frameworks/ubuntu-sdk-15.04.5-html.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.5-papi.framework
+++ b/frameworks/ubuntu-sdk-15.04.5-papi.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.5-qml.framework
+++ b/frameworks/ubuntu-sdk-15.04.5-qml.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.5.framework
+++ b/frameworks/ubuntu-sdk-15.04.5.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.6-html.framework
+++ b/frameworks/ubuntu-sdk-15.04.6-html.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.6-papi.framework
+++ b/frameworks/ubuntu-sdk-15.04.6-papi.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.6-qml.framework
+++ b/frameworks/ubuntu-sdk-15.04.6-qml.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.6.framework
+++ b/frameworks/ubuntu-sdk-15.04.6.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.7-html.framework
+++ b/frameworks/ubuntu-sdk-15.04.7-html.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.7-papi.framework
+++ b/frameworks/ubuntu-sdk-15.04.7-papi.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.7-qml.framework
+++ b/frameworks/ubuntu-sdk-15.04.7-qml.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.7.framework
+++ b/frameworks/ubuntu-sdk-15.04.7.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04

--- a/frameworks/ubuntu-sdk-15.04.framework
+++ b/frameworks/ubuntu-sdk-15.04.framework
@@ -1,2 +1,0 @@
-Base-Name: ubuntu-sdk
-Base-Version: 15.04


### PR DESCRIPTION
Since we have done such a big jump in both qt and toolchain version,
older frameworks are simply not supported. There is no way around this
but now is better then later.

DO NOT MERGE YET!

We need to update our coreapps to use the new framework before merging this.

