### PR TITLE
Remove click apps

### DIFF
--- a/desktop-armhf
+++ b/desktop-armhf
@@ -74,7 +74,6 @@ mobile-broadband-provider-info
 mtp-server
 nano
 network-manager
-notes-app
 nuntium
 ofono-scripts
 openssh-server

--- a/desktop-armhf
+++ b/desktop-armhf
@@ -14,7 +14,6 @@ apport-noui
 bluetooth-touch
 bluez
 ca-certificates
-camera-app
 ciborium
 click
 click-apparmor
@@ -31,7 +30,6 @@ fonts-nanum
 fonts-takao-pgothic
 fonts-wqy-microhei
 forkstat
-gallery-app
 gir1.2-accounts-1.0
 gir1.2-ubuntu-app-launch-2
 gstreamer0.10-opus


### PR DESCRIPTION
Since these are included [as clicks](https://github.com/ubports/build-tools/blob/master/clicks.list), we don't need the debs.