### PR TITLE
Remove cups for now

### DIFF
--- a/touch-arm64
+++ b/touch-arm64
@@ -246,7 +246,6 @@ ubuntu-location-provider-geoclue2
 account-polld-plugins-go
 hybris-usb
 cgroupfs-mount
-cups
 timekeeper
 qml-module-io-thp-pyotherside
 ubuntu-touch-coreapps

--- a/touch-armhf
+++ b/touch-armhf
@@ -250,7 +250,6 @@ ubuntu-location-provider-geoclue2
 account-polld-plugins-go
 hybris-usb
 cgroupfs-mount
-cups
 timekeeper
 qml-module-io-thp-pyotherside
 ubuntu-touch-coreapps


### PR DESCRIPTION
Due to https://github.com/ubports/ubuntu-touch/issues/673 we have to remove somthing, and since printer is not supported in ota4 we can safely remove cups for now and bring it back in ota5 https://github.com/ubports/ubuntu-touch/issues/679