### PR TITLE
Remove ubuntu-printing-app

### DIFF
--- a/touch-arm64
+++ b/touch-arm64
@@ -250,5 +250,3 @@ timekeeper
 qml-module-io-thp-pyotherside
 ubuntu-touch-coreapps
 xauth
-ubuntu-printing-app
-

--- a/touch-armhf
+++ b/touch-armhf
@@ -254,5 +254,3 @@ timekeeper
 qml-module-io-thp-pyotherside
 ubuntu-touch-coreapps
 xauth
-ubuntu-printing-app
-


### PR DESCRIPTION
Since cups was temporarily removed (#11), we don't need printing-app.