### PR TITLE
Remove unmaintained scopes, fix ubports/ubuntu-touch#722

### DIFF
--- a/touch-amd64
+++ b/touch-amd64
@@ -235,7 +235,6 @@ ubuntu-touch-sounds
 udisks2
 ufw
 unity-scope-click
-unity-scope-mediascanner2
 unity-scope-scopes
 unity-webapps-qml
 unity8

--- a/touch-arm64
+++ b/touch-arm64
@@ -228,7 +228,6 @@ ubuntu-touch-sounds
 udisks2
 ufw
 unity-scope-click
-unity-scope-mediascanner2
 unity-scope-scopes
 unity-webapps-qml
 unity8

--- a/touch-armhf
+++ b/touch-armhf
@@ -232,7 +232,6 @@ ubuntu-touch-sounds
 udisks2
 ufw
 unity-scope-click
-unity-scope-mediascanner2
 unity-scope-scopes
 unity-webapps-qml
 unity8

--- a/touch-i386
+++ b/touch-i386
@@ -235,7 +235,6 @@ ubuntu-touch-sounds
 udisks2
 ufw
 unity-scope-click
-unity-scope-mediascanner2
 unity-scope-scopes
 unity-webapps-qml
 unity8


### PR DESCRIPTION
This package contains scopes like the Music and Video aggregator.