### PR TITLE
Add libertine scope and settings component

### DIFF
--- a/touch-amd64
+++ b/touch-amd64
@@ -108,7 +108,6 @@ language-pack-touch-ug
 language-pack-touch-uk
 language-pack-touch-zh-hans
 language-pack-touch-zh-hant
-libertine-manager-app
 libertine-scope
 libertine-tools
 libhybris
@@ -227,6 +226,7 @@ ubuntu-keyboard-ukrainian
 ubuntu-location-service-bin
 ubuntu-push-client
 ubuntu-system-settings
+ubuntu-system-settings-libertine
 ubuntu-system-settings-online-accounts
 ubuntu-touch-customization-hooks
 ubuntu-touch-session

--- a/touch-amd64
+++ b/touch-amd64
@@ -108,6 +108,7 @@ language-pack-touch-ug
 language-pack-touch-uk
 language-pack-touch-zh-hans
 language-pack-touch-zh-hant
+libertine-scope
 libertine-tools
 libhybris
 libhybris-test
@@ -252,4 +253,3 @@ ubuntu-touch-coreapps
 xauth
 ubuntu-printing-app
 libsmbclient
-

--- a/touch-amd64
+++ b/touch-amd64
@@ -108,6 +108,7 @@ language-pack-touch-ug
 language-pack-touch-uk
 language-pack-touch-zh-hans
 language-pack-touch-zh-hant
+libertine-manager-app
 libertine-scope
 libertine-tools
 libhybris

--- a/touch-arm64
+++ b/touch-arm64
@@ -110,6 +110,7 @@ language-pack-touch-ug
 language-pack-touch-uk
 language-pack-touch-zh-hans
 language-pack-touch-zh-hant
+libertine-scope
 libertine-tools
 libhybris
 libhybris-test

--- a/touch-arm64
+++ b/touch-arm64
@@ -110,7 +110,6 @@ language-pack-touch-ug
 language-pack-touch-uk
 language-pack-touch-zh-hans
 language-pack-touch-zh-hant
-libertine-manager-app
 libertine-scope
 libertine-tools
 libhybris
@@ -219,6 +218,7 @@ ubuntu-keyboard-ukrainian
 ubuntu-location-service-bin
 ubuntu-push-client
 ubuntu-system-settings
+ubuntu-system-settings-libertine
 ubuntu-system-settings-online-accounts
 ubuntu-touch-customization-hooks
 ubuntu-touch-generic-initrd

--- a/touch-arm64
+++ b/touch-arm64
@@ -110,6 +110,7 @@ language-pack-touch-ug
 language-pack-touch-uk
 language-pack-touch-zh-hans
 language-pack-touch-zh-hant
+libertine-manager-app
 libertine-scope
 libertine-tools
 libhybris

--- a/touch-armhf
+++ b/touch-armhf
@@ -111,7 +111,6 @@ language-pack-touch-ug
 language-pack-touch-uk
 language-pack-touch-zh-hans
 language-pack-touch-zh-hant
-libertine-manager-app
 libertine-scope
 libertine-tools
 libhybris
@@ -223,6 +222,7 @@ ubuntu-keyboard-ukrainian
 ubuntu-location-service-bin
 ubuntu-push-client
 ubuntu-system-settings
+ubuntu-system-settings-libertine
 ubuntu-system-settings-online-accounts
 ubuntu-touch-customization-hooks
 ubuntu-touch-generic-initrd

--- a/touch-armhf
+++ b/touch-armhf
@@ -111,6 +111,7 @@ language-pack-touch-ug
 language-pack-touch-uk
 language-pack-touch-zh-hans
 language-pack-touch-zh-hant
+libertine-manager-app
 libertine-scope
 libertine-tools
 libhybris

--- a/touch-armhf
+++ b/touch-armhf
@@ -111,6 +111,7 @@ language-pack-touch-ug
 language-pack-touch-uk
 language-pack-touch-zh-hans
 language-pack-touch-zh-hant
+libertine-scope
 libertine-tools
 libhybris
 libhybris-test

--- a/touch-i386
+++ b/touch-i386
@@ -108,6 +108,7 @@ language-pack-touch-ug
 language-pack-touch-uk
 language-pack-touch-zh-hans
 language-pack-touch-zh-hant
+libertine-scope
 libertine-tools
 libhybris
 libhybris-test

--- a/touch-i386
+++ b/touch-i386
@@ -108,7 +108,6 @@ language-pack-touch-ug
 language-pack-touch-uk
 language-pack-touch-zh-hans
 language-pack-touch-zh-hant
-libertine-manager-app
 libertine-scope
 libertine-tools
 libhybris
@@ -227,6 +226,7 @@ ubuntu-keyboard-ukrainian
 ubuntu-location-service-bin
 ubuntu-push-client
 ubuntu-system-settings
+ubuntu-system-settings-libertine
 ubuntu-system-settings-online-accounts
 ubuntu-touch-customization-hooks
 ubuntu-touch-session

--- a/touch-i386
+++ b/touch-i386
@@ -108,6 +108,7 @@ language-pack-touch-ug
 language-pack-touch-uk
 language-pack-touch-zh-hans
 language-pack-touch-zh-hant
+libertine-manager-app
 libertine-scope
 libertine-tools
 libhybris


### PR DESCRIPTION
Since the libertine scope is building again (https://github.com/ubports/libertine-scope/pull/1), we can add it to the image. Fix ubports/ubuntu-touch#702