### PR TITLE
Switch the last two apps to click (terminal and filemanager)

### DIFF
--- a/touch-armhf
+++ b/touch-armhf
@@ -251,6 +251,5 @@ hybris-usb
 cgroupfs-mount
 timekeeper
 qml-module-io-thp-pyotherside
-ubuntu-touch-coreapps
 xauth
 libsmbclient


### PR DESCRIPTION
Fixes https://github.com/ubports/ubuntu-touch/issues/496

Note! I only did this for armhf right now, since we only have armhf clicks, so i left the others with debs for now until we have clicks in different arches.