### PR TITLE
Remove libertine-scope

### DIFF
--- a/touch-amd64
+++ b/touch-amd64
@@ -109,7 +109,6 @@ language-pack-touch-ug
 language-pack-touch-uk
 language-pack-touch-zh-hans
 language-pack-touch-zh-hant
-libertine-scope
 libertine-tools
 libhybris
 libhybris-test

--- a/touch-arm64
+++ b/touch-arm64
@@ -111,7 +111,6 @@ language-pack-touch-ug
 language-pack-touch-uk
 language-pack-touch-zh-hans
 language-pack-touch-zh-hant
-libertine-scope
 libertine-tools
 libhybris
 libhybris-test

--- a/touch-armhf
+++ b/touch-armhf
@@ -112,7 +112,6 @@ language-pack-touch-ug
 language-pack-touch-uk
 language-pack-touch-zh-hans
 language-pack-touch-zh-hant
-libertine-scope
 libertine-tools
 libhybris
 libhybris-test

--- a/touch-i386
+++ b/touch-i386
@@ -109,7 +109,6 @@ language-pack-touch-ug
 language-pack-touch-uk
 language-pack-touch-zh-hans
 language-pack-touch-zh-hant
-libertine-scope
 libertine-tools
 libhybris
 libhybris-test


### PR DESCRIPTION
As of https://github.com/ubports/ubuntu-touch/issues/782, we will remove the libertine scope again.