### PR TITLE
Add QtQuick.Controls for browser-ng

### DIFF
--- a/touch-amd64
+++ b/touch-amd64
@@ -256,3 +256,4 @@ ubuntu-touch-coreapps
 xauth
 ubuntu-printing-app
 libsmbclient
+qml-module-qtquick-controls

--- a/touch-arm64
+++ b/touch-arm64
@@ -252,3 +252,4 @@ qml-module-io-thp-pyotherside
 ubuntu-touch-coreapps
 xauth
 libsmbclient
+qml-module-qtquick-controls

--- a/touch-armhf
+++ b/touch-armhf
@@ -255,3 +255,4 @@ timekeeper
 qml-module-io-thp-pyotherside
 xauth
 libsmbclient
+qml-module-qtquick-controls

--- a/touch-i386
+++ b/touch-i386
@@ -254,3 +254,4 @@ ubuntu-location-provider-geoclue2
 qml-module-io-thp-pyotherside
 ubuntu-printing-app
 libsmbclient
+qml-module-qtquick-controls


### PR DESCRIPTION
This module is currently missing for browser-ng to get a context menu.