### PR TITLE
Add symlink to current framework, used by wizard

### DIFF
--- a/debian/ubuntu-sdk-libs.links
+++ b/debian/ubuntu-sdk-libs.links
@@ -1,0 +1,1 @@
+usr/share/click/frameworks/ubuntu-sdk-16.04.framework usr/share/click/frameworks/current


### PR DESCRIPTION
This adds a symlink to the current framework, this is needed so the wizard knows when to do show app update wizard or not.