### PR TITLE
The end of oxide, start of morph

### DIFF
--- a/desktop-amd64
+++ b/desktop-amd64
@@ -150,8 +150,8 @@ unity8-desktop-session-mir
 urfkill
 url-dispatcher
 usensord
-webapp-container
-webbrowser-app
+morph-webapp-container
+morph-browser
 wget
 whoopsie
 wireless-tools

--- a/desktop-arm64
+++ b/desktop-arm64
@@ -150,8 +150,8 @@ unity8-desktop-session-mir
 urfkill
 url-dispatcher
 usensord
-webapp-container
-webbrowser-app
+morph-webapp-container
+morph-browser
 wget
 whoopsie
 wireless-tools

--- a/desktop-armhf
+++ b/desktop-armhf
@@ -150,8 +150,8 @@ unity8-desktop-session-mir
 urfkill
 url-dispatcher
 usensord
-webapp-container
-webbrowser-app
+morph-webapp-container
+morph-browser
 wget
 whoopsie
 wireless-tools

--- a/desktop-i386
+++ b/desktop-i386
@@ -150,8 +150,8 @@ unity8-desktop-session-mir
 urfkill
 url-dispatcher
 usensord
-webapp-container
-webbrowser-app
+morph-webapp-container
+morph-browser
 wget
 whoopsie
 wireless-tools

--- a/touch-amd64
+++ b/touch-amd64
@@ -148,7 +148,6 @@ ofono
 ofono-scripts
 openssh-server
 openvpn
-oxideqt-codecs-extra
 packagekit
 packagekit-plugin-click
 packagekit-tools
@@ -246,8 +245,8 @@ upstart-watchdog
 urfkill
 url-dispatcher
 usensord
-webapp-container
-webbrowser-app
+morph-webapp-container
+morph-browser
 wget
 whoopsie
 wireless-tools

--- a/touch-arm64
+++ b/touch-arm64
@@ -143,7 +143,6 @@ ofono
 ofono-scripts
 openssh-server
 openvpn
-oxideqt-codecs-extra
 packagekit
 packagekit-plugin-click
 packagekit-tools
@@ -239,8 +238,8 @@ upstart-watchdog
 urfkill
 url-dispatcher
 usensord
-webapp-container
-webbrowser-app
+morph-webapp-container
+morph-browser
 wget
 whoopsie
 wireless-tools

--- a/touch-armhf
+++ b/touch-armhf
@@ -145,7 +145,6 @@ ofono
 ofono-scripts
 openssh-server
 openvpn
-oxideqt-codecs-extra
 packagekit
 packagekit-plugin-click
 packagekit-tools
@@ -244,8 +243,8 @@ upstart-watchdog
 urfkill
 url-dispatcher
 usensord
-webapp-container
-webbrowser-app
+morph-webapp-container
+morph-browser
 wget
 whoopsie
 wireless-tools

--- a/touch-i386
+++ b/touch-i386
@@ -148,7 +148,6 @@ ofono
 ofono-scripts
 openssh-server
 openvpn
-oxideqt-codecs-extra
 packagekit
 packagekit-plugin-click
 packagekit-tools
@@ -246,8 +245,8 @@ upstart-watchdog
 urfkill
 url-dispatcher
 usensord
-webapp-container
-webbrowser-app
+morph-webapp-container
+morph-browser
 wget
 whoopsie
 wireless-tools


### PR DESCRIPTION
This replaces (some) oxide with morph (qtwebengine)!

This *may* break some apps, but most web apps *should* work.

This does not yet remove oxide and replaces Ubuntu.Web with the QtWebEngine version.