### PR TITLE
Add qml-module-qt-labs-platform

### DIFF
--- a/sdk-libs-amd64
+++ b/sdk-libs-amd64
@@ -7,6 +7,7 @@ libqt5multimedia5-plugins
 libqt5script5
 libqt5sql5-sqlite
 qml-module-qt-labs-settings
+qml-module-qt-labs-platform
 qml-module-qt-websockets
 qml-module-qtbluetooth
 qml-module-qtgraphicaleffects

--- a/sdk-libs-arm64
+++ b/sdk-libs-arm64
@@ -7,6 +7,7 @@ libqt5multimedia5-plugins
 libqt5script5
 libqt5sql5-sqlite
 qml-module-qt-labs-settings
+qml-module-qt-labs-platform
 qml-module-qt-websockets
 qml-module-qtbluetooth
 qml-module-qtgraphicaleffects

--- a/sdk-libs-armhf
+++ b/sdk-libs-armhf
@@ -7,6 +7,7 @@ libqt5multimedia5-plugins
 libqt5script5
 libqt5sql5-sqlite
 qml-module-qt-labs-settings
+qml-module-qt-labs-platform
 qml-module-qt-websockets
 qml-module-qtbluetooth
 qml-module-qtgraphicaleffects

--- a/sdk-libs-i386
+++ b/sdk-libs-i386
@@ -7,6 +7,7 @@ libqt5multimedia5-plugins
 libqt5script5
 libqt5sql5-sqlite
 qml-module-qt-labs-settings
+qml-module-qt-labs-platform
 qml-module-qt-websockets
 qml-module-qtbluetooth
 qml-module-qtgraphicaleffects


### PR DESCRIPTION
This way the StandardPaths to app config, cache and app data become available via QML (see [docs](https://doc.qt.io/archives/qt-5.10/qml-qt-labs-platform-standardpaths.html) and [ubports docs](https://docs.ubports.com/en/latest/appdev/guides/writeable-dirs.html))