### PR TITLE
Ensure that Oxide is kept in the image until we explicitly remove it

### DIFF
--- a/sdk-libs-amd64
+++ b/sdk-libs-amd64
@@ -22,6 +22,7 @@ qml-module-ubuntu-onlineaccounts
 qml-module-qtquick-controls2
 qml-module-qtquick-controls2-suru
 qml-module-qtwebengine
+qml-module-ubuntu-web
 qmlscene
 qtchooser
 qt5-image-formats-plugins

--- a/sdk-libs-arm64
+++ b/sdk-libs-arm64
@@ -22,6 +22,7 @@ qml-module-ubuntu-onlineaccounts
 qml-module-qtquick-controls2
 qml-module-qtquick-controls2-suru
 qml-module-qtwebengine
+qml-module-ubuntu-web
 qmlscene
 qtchooser
 qt5-image-formats-plugins

--- a/sdk-libs-armhf
+++ b/sdk-libs-armhf
@@ -22,6 +22,7 @@ qml-module-ubuntu-onlineaccounts
 qml-module-qtquick-controls2
 qml-module-qtquick-controls2-suru
 qml-module-qtwebengine
+qml-module-ubuntu-web
 qmlscene
 qtchooser
 qt5-image-formats-plugins

--- a/sdk-libs-i386
+++ b/sdk-libs-i386
@@ -20,6 +20,7 @@ qml-module-qtsensors
 qml-module-qtsysteminfo
 qml-module-ubuntu-onlineaccounts
 qml-module-qtwebengine
+qml-module-ubuntu-web
 qmlscene
 qtchooser
 qt5-image-formats-plugins


### PR DESCRIPTION
Unity8 is currently the only thing which depends on the Ubuntu.Web module, meaning it will be removed after https://github.com/ubports/unity8/pull/91 is merged. This PR ensures that Ubuntu.Web sticks around until we decide we can remove it.