### PR TITLE
Remove htop

### DIFF
--- a/touch-core-amd64
+++ b/touch-core-amd64
@@ -31,7 +31,6 @@ gstreamer1.0-plugins-good
 gstreamer1.0-plugins-ugly-amr
 gstreamer1.0-pulseaudio
 health-check
-htop
 iw
 libertine-scope
 libertine-tools

--- a/touch-core-arm64
+++ b/touch-core-arm64
@@ -31,7 +31,6 @@ gstreamer1.0-plugins-good
 gstreamer1.0-plugins-ugly-amr
 gstreamer1.0-pulseaudio
 health-check
-htop
 iw
 libertine-scope
 libertine-tools

--- a/touch-core-armhf
+++ b/touch-core-armhf
@@ -31,7 +31,6 @@ gstreamer1.0-plugins-good
 gstreamer1.0-plugins-ugly-amr
 gstreamer1.0-pulseaudio
 health-check
-htop
 iw
 libertine-scope
 libertine-tools


### PR DESCRIPTION
We added htop to the image on a whim when preparing for (i think) ota-3. In hindsight, i'm not sure that was the best idea, and there are a couple of reasons for that. For one, most users don't need it on a regular basis, and those who do are likely power users who could just as well install the deb package or use [this](https://open-store.io/app/htop.emanuelesorce). But the main reason i'm filing this pr is because it resolves (or rather avoids the issue, i'll look into actually resolving it later) half of https://github.com/ubports/ubuntu-touch/issues/1065 and also helps a teensy little bit with https://github.com/ubports/ubuntu-touch/issues/1078.

Requesting review from the people who i think were part of the decision to include it back in the day. What do you think, is this stupid, or should we maybe even go even farther and look for more nonessential stuff we can remove?