### PR TITLE
Remove Libertine scope

### DIFF
--- a/touch-core-amd64
+++ b/touch-core-amd64
@@ -32,7 +32,6 @@ gstreamer1.0-plugins-ugly-amr
 gstreamer1.0-pulseaudio
 health-check
 iw
-libertine-scope
 libertine-tools
 libmediainfo0v5
 libmessaging-menu0

--- a/touch-core-arm64
+++ b/touch-core-arm64
@@ -32,7 +32,6 @@ gstreamer1.0-plugins-ugly-amr
 gstreamer1.0-pulseaudio
 health-check
 iw
-libertine-scope
 libertine-tools
 libmediainfo0v5
 libmessaging-menu0

--- a/touch-core-armhf
+++ b/touch-core-armhf
@@ -32,7 +32,6 @@ gstreamer1.0-plugins-ugly-amr
 gstreamer1.0-pulseaudio
 health-check
 iw
-libertine-scope
 libertine-tools
 libmediainfo0v5
 libmessaging-menu0


### PR DESCRIPTION
No longer needed, as libertine apps are now displayed in the application drawer.