### PR TITLE
Remove geoclue2 backend from image.

### DIFF
--- a/touch-amd64
+++ b/touch-amd64
@@ -255,7 +255,6 @@ morph-webapp-container
 morph-browser
 wget
 wireless-tools
-ubuntu-location-provider-geoclue2
 qml-module-io-thp-pyotherside
 ubuntu-touch-coreapps
 xauth

--- a/touch-arm64
+++ b/touch-arm64
@@ -250,7 +250,6 @@ morph-webapp-container
 morph-browser
 wget
 wireless-tools
-ubuntu-location-provider-geoclue2
 account-polld-plugins-go
 hybris-usb
 cgroupfs-mount

--- a/touch-armhf
+++ b/touch-armhf
@@ -250,7 +250,6 @@ morph-webapp-container
 morph-browser
 wget
 wireless-tools
-ubuntu-location-provider-geoclue2
 account-polld-plugins-go
 hybris-usb
 cgroupfs-mount

--- a/touch-i386
+++ b/touch-i386
@@ -250,7 +250,6 @@ morph-webapp-container
 morph-browser
 wget
 wireless-tools
-ubuntu-location-provider-geoclue2
 qml-module-io-thp-pyotherside
 ubuntu-printing-app
 libsmbclient


### PR DESCRIPTION
As the geoclue2 (wolfpack) backend appears to have questionable history, no
clear licensing/copyright information, and doesn't actually work currently
anyway, remove it from the images.