### PR TITLE
Add new frameworks to edge

### DIFF
--- a/debian/ubuntu-sdk-libs.links
+++ b/debian/ubuntu-sdk-libs.links
@@ -1,2 +1,2 @@
-usr/share/click/frameworks/ubuntu-sdk-16.04.framework usr/share/click/frameworks/current
+usr/share/click/frameworks/ubuntu-sdk-16.04.1.framework usr/share/click/frameworks/current
 usr/share/ubports/changelogs/16.04 usr/share/ubports/changelogs/current

--- a/frameworks/ubuntu-sdk-16.04.1-html.framework
+++ b/frameworks/ubuntu-sdk-16.04.1-html.framework
@@ -1,0 +1,2 @@
+Base-Name: ubuntu-sdk
+Base-Version: 16.04

--- a/frameworks/ubuntu-sdk-16.04.1-papi.framework
+++ b/frameworks/ubuntu-sdk-16.04.1-papi.framework
@@ -1,0 +1,2 @@
+Base-Name: ubuntu-sdk
+Base-Version: 16.04

--- a/frameworks/ubuntu-sdk-16.04.1-qml.framework
+++ b/frameworks/ubuntu-sdk-16.04.1-qml.framework
@@ -1,0 +1,2 @@
+Base-Name: ubuntu-sdk
+Base-Version: 16.04

--- a/frameworks/ubuntu-sdk-16.04.1.framework
+++ b/frameworks/ubuntu-sdk-16.04.1.framework
@@ -1,0 +1,2 @@
+Base-Name: ubuntu-sdk
+Base-Version: 16.04

--- a/frameworks/ubuntu-sdk-16.04.2-html.framework
+++ b/frameworks/ubuntu-sdk-16.04.2-html.framework
@@ -1,0 +1,2 @@
+Base-Name: ubuntu-sdk
+Base-Version: 16.04

--- a/frameworks/ubuntu-sdk-16.04.2-papi.framework
+++ b/frameworks/ubuntu-sdk-16.04.2-papi.framework
@@ -1,0 +1,2 @@
+Base-Name: ubuntu-sdk
+Base-Version: 16.04

--- a/frameworks/ubuntu-sdk-16.04.2-qml.framework
+++ b/frameworks/ubuntu-sdk-16.04.2-qml.framework
@@ -1,0 +1,2 @@
+Base-Name: ubuntu-sdk
+Base-Version: 16.04

--- a/frameworks/ubuntu-sdk-16.04.2.framework
+++ b/frameworks/ubuntu-sdk-16.04.2.framework
@@ -1,0 +1,2 @@
+Base-Name: ubuntu-sdk
+Base-Version: 16.04


### PR DESCRIPTION
Add the 16.04.1 and 16.04.2 frameworks to the edge channel images.

Since the `xenial` and `xenial_-_edge` versions of this repository have diverged, I have basically resolved myself to forcing `xenial_-_edge` over `xenial` when the time comes to merge these two histories. I know this is messy, but this repository is becoming more automatically generated, and for that reason I feel it is okay to save the history of `xenial` to a tag prior to merge, then rewriting history a bit.