### PR TITLE
Add qtcharts module.

### DIFF
--- a/sdk-libs-amd64
+++ b/sdk-libs-amd64
@@ -9,6 +9,7 @@ libqt5sql5-sqlite
 qml-module-qt-labs-settings
 qml-module-qt-websockets
 qml-module-qtbluetooth
+qml-module-qtcharts
 qml-module-qtgraphicaleffects
 qml-module-qtlocation
 qml-module-qtmultimedia

--- a/sdk-libs-arm64
+++ b/sdk-libs-arm64
@@ -9,6 +9,7 @@ libqt5sql5-sqlite
 qml-module-qt-labs-settings
 qml-module-qt-websockets
 qml-module-qtbluetooth
+qml-module-qtcharts
 qml-module-qtgraphicaleffects
 qml-module-qtlocation
 qml-module-qtmultimedia

--- a/sdk-libs-armhf
+++ b/sdk-libs-armhf
@@ -9,6 +9,7 @@ libqt5sql5-sqlite
 qml-module-qt-labs-settings
 qml-module-qt-websockets
 qml-module-qtbluetooth
+qml-module-qtcharts
 qml-module-qtgraphicaleffects
 qml-module-qtlocation
 qml-module-qtmultimedia

--- a/sdk-libs-i386
+++ b/sdk-libs-i386
@@ -9,6 +9,7 @@ libqt5sql5-sqlite
 qml-module-qt-labs-settings
 qml-module-qt-websockets
 qml-module-qtbluetooth
+qml-module-qtcharts
 qml-module-qtgraphicaleffects
 qml-module-qtlocation
 qml-module-qtmultimedia


### PR DESCRIPTION
This adds the qtcharts module to the image, and requires first that the qtcharts packages be built into the ubports repo. It adds about 2MB more to uncompressed rootfs.