### PR TITLE
touch: Add pulseaudio-modules-droid-glue-24

### DIFF
--- a/touch-amd64
+++ b/touch-amd64
@@ -156,8 +156,9 @@ powerstat
 pulseaudio
 pulseaudio-module-bluetooth
 pulseaudio-module-droid
-pulseaudio-modules-droid-24
 pulseaudio-module-trust-store
+pulseaudio-modules-droid-24
+pulseaudio-modules-droid-glue-24
 pulseaudio-utils
 python3-gi
 python3-libertine-chroot

--- a/touch-arm64
+++ b/touch-arm64
@@ -153,8 +153,9 @@ powerstat
 pulseaudio
 pulseaudio-module-bluetooth
 pulseaudio-module-droid
-pulseaudio-modules-droid-24
 pulseaudio-module-trust-store
+pulseaudio-modules-droid-24
+pulseaudio-modules-droid-glue-24
 pulseaudio-utils
 python3-gi
 python3-libertine-chroot

--- a/touch-armhf
+++ b/touch-armhf
@@ -153,8 +153,9 @@ powerstat
 pulseaudio
 pulseaudio-module-bluetooth
 pulseaudio-module-droid
-pulseaudio-modules-droid-24
 pulseaudio-module-trust-store
+pulseaudio-modules-droid-24
+pulseaudio-modules-droid-glue-24
 pulseaudio-utils
 python3-gi
 python3-libertine-chroot

--- a/touch-i386
+++ b/touch-i386
@@ -155,8 +155,9 @@ powerstat
 pulseaudio
 pulseaudio-module-bluetooth
 pulseaudio-module-droid
-pulseaudio-modules-droid-24
 pulseaudio-module-trust-store
+pulseaudio-modules-droid-24
+pulseaudio-modules-droid-glue-24
 pulseaudio-utils
 python3-gi
 python3-libertine-chroot


### PR DESCRIPTION
This PulseAudio module is required for calling to work on Android 7.1-based adaptations.