### PR TITLE
touch-hybris: add mir-platform-graphics-android-caf15

### DIFF
--- a/touch-hybris-amd64
+++ b/touch-hybris-amd64
@@ -9,6 +9,7 @@ libhybris-utils
 lxc-android-config
 mir-graphics-drivers-android
 mir-graphics-drivers-android-caf
+mir-platform-graphics-android-caf15
 pulseaudio-module-droid
 pulseaudio-modules-droid-24
 qtmir-android

--- a/touch-hybris-arm64
+++ b/touch-hybris-arm64
@@ -10,6 +10,7 @@ libhybris-utils
 lxc-android-config
 mir-graphics-drivers-android
 mir-graphics-drivers-android-caf
+mir-platform-graphics-android-caf15
 pulseaudio-module-droid
 pulseaudio-modules-droid-24
 qtmir-android

--- a/touch-hybris-armhf
+++ b/touch-hybris-armhf
@@ -10,6 +10,7 @@ libhybris-utils
 lxc-android-config
 mir-graphics-drivers-android
 mir-graphics-drivers-android-caf
+mir-platform-graphics-android-caf15
 pulseaudio-module-droid
 pulseaudio-modules-droid-24
 qtmir-android


### PR DESCRIPTION
mir-platform-graphics-android-caf15 seems to be needed by a bunch of halium-7.1 devices on edge