### PR TITLE
WIP: Remove qml-module-io-thp-pyotherside from sdk-libs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ubuntu-touch-meta (1.433xenial1ubports13) xenial; urgency=medium
+
+  * Removed qml-module-io-thp-pyotherside to sdk-libs (Fixes:
+    https://github.com/ubports/ubuntu-touch-meta/issues/56)
+
+ -- Alberto Mardegan <mardy@users.sourceforge.net>  Thu, 12 Dec 2019 22:49:09 +0300
+
 ubuntu-touch-meta (1.433xenial1ubports12) xenial; urgency=medium
 
   * Refreshed dependencies

--- a/sdk-libs-amd64
+++ b/sdk-libs-amd64
@@ -6,7 +6,6 @@ libqt5keychain0
 libqt5multimedia5-plugins
 libqt5script5
 libqt5sql5-sqlite
-qml-module-io-thp-pyotherside
 qml-module-org-kde-kirigami2
 qml-module-qmltermwidget1.0
 qml-module-qt-labs-folderlistmodel

--- a/sdk-libs-arm64
+++ b/sdk-libs-arm64
@@ -6,7 +6,6 @@ libqt5keychain0
 libqt5multimedia5-plugins
 libqt5script5
 libqt5sql5-sqlite
-qml-module-io-thp-pyotherside
 qml-module-org-kde-kirigami2
 qml-module-qmltermwidget1.0
 qml-module-qt-labs-folderlistmodel

--- a/sdk-libs-armhf
+++ b/sdk-libs-armhf
@@ -6,7 +6,6 @@ libqt5keychain0
 libqt5multimedia5-plugins
 libqt5script5
 libqt5sql5-sqlite
-qml-module-io-thp-pyotherside
 qml-module-org-kde-kirigami2
 qml-module-qmltermwidget1.0
 qml-module-qt-labs-folderlistmodel


### PR DESCRIPTION
The package cannot be cross-installed on armhf (and possibly on arm64
too) and it breaks the build of the SDK images and of the clickable
Docker image.

Fixes: https://github.com/ubports/ubuntu-touch-meta/issues/56