### PR TITLE
touch: remove address-book-updater

### DIFF
--- a/touch-amd64
+++ b/touch-amd64
@@ -8,7 +8,6 @@ account-plugin-twitter
 account-plugin-vk
 account-polld-plugins-go
 address-book-app
-address-book-updater
 bluez-obexd
 dialer-app
 fonts-emojione

--- a/touch-arm64
+++ b/touch-arm64
@@ -8,7 +8,6 @@ account-plugin-twitter
 account-plugin-vk
 account-polld-plugins-go
 address-book-app
-address-book-updater
 bluez-obexd
 dialer-app
 fonts-emojione

--- a/touch-armhf
+++ b/touch-armhf
@@ -8,7 +8,6 @@ account-plugin-twitter
 account-plugin-vk
 account-polld-plugins-go
 address-book-app
-address-book-updater
 bluez-obexd
 dialer-app
 fonts-emojione

--- a/touch-i386
+++ b/touch-i386
@@ -8,7 +8,6 @@ account-plugin-ubuntuone
 account-plugin-vk
 account-polld
 address-book-app
-address-book-updater
 aethercast
 alsa-base
 alsa-utils


### PR DESCRIPTION
With https://github.com/ubports/address-book-app/pull/196 the
address-book-updater is added as a dependency of address-book-app (which
is already in the UT meta seed).

To be merged after https://github.com/ubports/address-book-app/pull/196

Contributes to https://github.com/ubports/ubuntu-touch/issues/997